### PR TITLE
add browser package as dev dependency

### DIFF
--- a/example/demos/demos.html
+++ b/example/demos/demos.html
@@ -87,9 +87,7 @@
         document.body.appendChild(menu);
       }
     </script>
-    <script
-      src="https://dart.googlecode.com/svn/branches/bleeding_edge/dart/client/dart.js">
-    </script>
+    <script src="packages/browser/dart.js"></script>
   </body>
 </html>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,3 +5,4 @@ author: Dominic Hamon <dominic@google.com>
 homepage: http://github.com/dart-lang/dart-box2d
 dev_dependencies:
   args: any
+  browser: any


### PR DESCRIPTION
For running the examples the current version of dart.js is needed.
