### PR TITLE
change attribute type hints form num to double

### DIFF
--- a/example/benchmarks/ball_cage_bench.dart
+++ b/example/benchmarks/ball_cage_bench.dart
@@ -22,10 +22,10 @@ class BallCageBench extends Benchmark {
   static const double START_Y = -20.0;
 
   /** The radius of the balls forming the arena. */
-  static const num WALL_BALL_RADIUS = 2;
+  static const double WALL_BALL_RADIUS = 2.0;
 
   /** Radius of the active ball. */
-  static const num ACTIVE_BALL_RADIUS = 1;
+  static const double ACTIVE_BALL_RADIUS = 1.0;
 
   /** Constructs a new BallCage. */
   BallCageBench(List<int> solveLoops, List<int> steps) :
@@ -44,7 +44,7 @@ class BallCageBench extends Benchmark {
     final circleFixtureDef = new FixtureDef();
     circleFixtureDef.shape = circleShape;
     circleFixtureDef.friction = .9;
-    circleFixtureDef.restitution = 1;
+    circleFixtureDef.restitution = 1.0;
 
     // Create a body def.
     final circleBodyDef = new BodyDef();
@@ -84,7 +84,7 @@ class BallCageBench extends Benchmark {
 
     // Create fixture for that ball shape.
     final activeFixtureDef = new FixtureDef();
-    activeFixtureDef.restitution = 1;
+    activeFixtureDef.restitution = 1.0;
     activeFixtureDef.density =  0.05;
     activeFixtureDef.shape = bouncingCircle;
 

--- a/example/benchmarks/ball_drop_bench.dart
+++ b/example/benchmarks/ball_drop_bench.dart
@@ -36,7 +36,7 @@ class BallDropBench extends Benchmark {
     // Create the fixture to attach to the ball body.
     final fd = new FixtureDef();
     final cd = new CircleShape();
-    cd.radius = 1;
+    cd.radius = 1.0;
     fd.shape = cd;
 
     // Define and create the ball body. Attach the fixture.

--- a/example/benchmarks/circle_stress_bench.dart
+++ b/example/benchmarks/circle_stress_bench.dart
@@ -93,7 +93,7 @@ class CircleStressBench extends Benchmark {
       sd.setAsBox(50.0, 10.0);
       final topDef = new BodyDef();
       topDef.type = BodyType.STATIC;
-      topDef.angle = 0;
+      topDef.angle = 0.0;
       topDef.position = new Vector2(0.0, 75.0);
       final topBody = world.createBody(topDef);
       bodies.add(topBody);
@@ -116,7 +116,7 @@ class CircleStressBench extends Benchmark {
         final cd = new CircleShape();
         cd.radius = 1.2;
         fd.shape = cd;
-        fd.density = 25;
+        fd.density = 25.0;
         fd.friction = .1;
         fd.restitution = .9;
         num xPos = radius * cos(2 * PI * (i / numPieces.toDouble()));

--- a/example/benchmarks/domino_platform_bench.dart
+++ b/example/benchmarks/domino_platform_bench.dart
@@ -82,7 +82,7 @@ class DominoPlatformBench extends Benchmark {
             bd.angle = .1;
             bd.position.x -= .1;
           } else {
-            bd.angle = 0;
+            bd.angle = 0.0;
           }
           Body myBody = world.createBody(bd);
           myBody.createFixture(fd);

--- a/example/benchmarks/domino_tower_bench.dart
+++ b/example/benchmarks/domino_tower_bench.dart
@@ -15,9 +15,9 @@
 part of BenchmarkRunner;
 
 class DominoTowerBench extends Benchmark {
-  static const num DOMINO_WIDTH = .2;
-  static const num DOMINO_FRICTION = 0.1;
-  static const num DOMINO_HEIGHT = 1;
+  static const double DOMINO_WIDTH = .2;
+  static const double DOMINO_FRICTION = 0.1;
+  static const double DOMINO_HEIGHT = 1.0;
   static const num BASE_COUNT = 25;
   static const String NAME = "Domino Tower";
 
@@ -25,7 +25,7 @@ class DominoTowerBench extends Benchmark {
    * The density of the dominos under construction. Varies for different parts
    * of the tower.
    */
-  num dominoDensity;
+  double dominoDensity;
 
   /** Construct a new DominoTower. */
   DominoTowerBench(List<int> solveLoops, List<int> steps) :
@@ -44,7 +44,7 @@ class DominoTowerBench extends Benchmark {
     fd.friction = DOMINO_FRICTION;
     fd.restitution = 0.65;
     bd.position = new Vector2(x, y);
-    bd.angle = horizontal ? (PI / 2.0) : 0;
+    bd.angle = horizontal ? (PI / 2.0) : 0.0;
     Body myBody = world_.createBody(bd);
     myBody.createFixture(fd);
     bodies.add(myBody);
@@ -69,16 +69,16 @@ class DominoTowerBench extends Benchmark {
     }
 
     {
-      dominoDensity = 10;
+      dominoDensity = 10.0;
       // Make bullet
       PolygonShape sd = new PolygonShape();
       sd.setAsBox(.7, .7);
       FixtureDef fd = new FixtureDef();
-      fd.density = 35;
+      fd.density = 35.0;
       BodyDef bd = new BodyDef();
       bd.type = BodyType.DYNAMIC;
       fd.shape = sd;
-      fd.friction = 0;
+      fd.friction = 0.0;
       fd.restitution = 0.85;
       bd.bullet = true;
       bd.position = new Vector2(30.0, 50.0);
@@ -88,7 +88,7 @@ class DominoTowerBench extends Benchmark {
       b.linearVelocity = new Vector2(-25.0, -25.0);
       b.angularVelocity = 6.7;
 
-      fd.density = 25;
+      fd.density = 25.0;
       bd.position = new Vector2(-30.0, 25.0);
       b = world.createBody(bd);
       bodies.add(b);

--- a/example/demos/ball_cage.dart
+++ b/example/demos/ball_cage.dart
@@ -24,10 +24,10 @@ class BallCage extends Demo {
   static const double START_Y = -20.0;
 
   /** The radius of the balls forming the arena. */
-  static const num WALL_BALL_RADIUS = 2;
+  static const num WALL_BALL_RADIUS = 2.0;
 
   /** Radius of the active ball. */
-  static const num ACTIVE_BALL_RADIUS = 1;
+  static const num ACTIVE_BALL_RADIUS = 1.0;
 
   /** Constructs a new BallCage. */
   BallCage() : super("Ball cage") { }
@@ -49,7 +49,7 @@ class BallCage extends Demo {
     final circleFixtureDef = new FixtureDef();
     circleFixtureDef.shape = circleShape;
     circleFixtureDef.friction = .9;
-    circleFixtureDef.restitution = 1;
+    circleFixtureDef.restitution = 1.0;
 
     // Create a body def.
     final circleBodyDef = new BodyDef();
@@ -89,7 +89,7 @@ class BallCage extends Demo {
 
     // Create fixture for that ball shape.
     final activeFixtureDef = new FixtureDef();
-    activeFixtureDef.restitution = 1;
+    activeFixtureDef.restitution = 1.0;
     activeFixtureDef.density =  0.05;
     activeFixtureDef.shape = bouncingCircle;
 

--- a/example/demos/circle_stress.dart
+++ b/example/demos/circle_stress.dart
@@ -23,7 +23,7 @@ class CircleStress extends Demo {
   RevoluteJoint _joint;
 
   /** Scale of the viewport for this Demo. */
-  static const num _MY_VIEWPORT_SCALE = 4;
+  static const double _MY_VIEWPORT_SCALE = 4.0;
 
   /** The number of columns of balls in the pen. */
   static const int COLUMNS = 8;
@@ -102,7 +102,7 @@ class CircleStress extends Demo {
       sd.setAsBox(50.0, 10.0);
       final topDef = new BodyDef();
       topDef.type = BodyType.STATIC;
-      topDef.angle = 0;
+      topDef.angle = 0.0;
       topDef.position = new Vector2(0.0, 75.0);
       final topBody = world.createBody(topDef);
       bodies.add(topBody);
@@ -125,7 +125,7 @@ class CircleStress extends Demo {
         final cd = new CircleShape();
         cd.radius = 1.2;
         fd.shape = cd;
-        fd.density = 25;
+        fd.density = 25.0;
         fd.friction = .1;
         fd.restitution = .9;
         num xPos = radius * Math.cos(2 * Math.PI * (i / numPieces.toDouble()));

--- a/example/demos/demo.dart
+++ b/example/demos/demo.dart
@@ -30,7 +30,7 @@ abstract class Demo {
   static const int CANVAS_HEIGHT = 600;
 
   /** Scale of the viewport. */
-  static const num _VIEWPORT_SCALE = 10;
+  static const double _VIEWPORT_SCALE = 10.0;
 
   /** The gravity vector's y value. */
   static const double GRAVITY = -10.0;
@@ -69,7 +69,7 @@ abstract class Demo {
 
   // TODO(dominich): Make this library-private once optional positional
   // parameters are introduced.
-  num viewportScale;
+  double viewportScale;
 
   // For timing the world.step call. It is kept running but reset and polled
   // every frame to minimize overhead.

--- a/example/demos/domino_test.dart
+++ b/example/demos/domino_test.dart
@@ -77,7 +77,7 @@ class DominoTest extends Demo {
             bd.angle = .1;
             bd.position.x -= .1;
           } else {
-            bd.angle = 0;
+            bd.angle = 0.0;
           }
           Body myBody = world.createBody(bd);
           myBody.createFixture(fd);

--- a/example/demos/domino_tower.dart
+++ b/example/demos/domino_tower.dart
@@ -22,14 +22,14 @@ import 'demo.dart';
 class DominoTower extends Demo {
   static const num DOMINO_WIDTH = .2;
   static const num DOMINO_FRICTION = 0.1;
-  static const num DOMINO_HEIGHT = 1;
+  static const num DOMINO_HEIGHT = 1.0;
   static const num BASE_COUNT = 25;
 
   /**
    * The density of the dominos under construction. Varies for different parts
    * of the tower.
    */
-  num dominoDensity;
+  double dominoDensity;
 
   /** Construct a new DominoTower. */
   DominoTower() : super("Domino tower") { }
@@ -53,7 +53,7 @@ class DominoTower extends Demo {
     fd.friction = DOMINO_FRICTION;
     fd.restitution = 0.65;
     bd.position = new Vector2(x, y);
-    bd.angle = horizontal ? (Math.PI / 2.0) : 0;
+    bd.angle = horizontal ? (Math.PI / 2.0) : 0.0;
     Body myBody = world.createBody(bd);
     myBody.createFixture(fd);
     bodies.add(myBody);
@@ -76,16 +76,16 @@ class DominoTower extends Demo {
     }
 
     {
-      dominoDensity = 10;
+      dominoDensity = 10.0;
       // Make bullet
       PolygonShape sd = new PolygonShape();
       sd.setAsBox(.7, .7);
       FixtureDef fd = new FixtureDef();
-      fd.density = 35;
+      fd.density = 35.0;
       BodyDef bd = new BodyDef();
       bd.type = BodyType.DYNAMIC;
       fd.shape = sd;
-      fd.friction = 0;
+      fd.friction = 0.0;
       fd.restitution = 0.85;
       bd.bullet = true;
       bd.position = new Vector2(30.0, 5.00);
@@ -95,7 +95,7 @@ class DominoTower extends Demo {
       b.linearVelocity = new Vector2(-25.0, -25.0);
       b.angularVelocity = 6.7;
 
-      fd.density = 25;
+      fd.density = 25.0;
       bd.position = new Vector2(-30.0, 25.0);
       b = world.createBody(bd);
       bodies.add(b);

--- a/lib/src/callbacks/contact_impulse.dart
+++ b/lib/src/callbacks/contact_impulse.dart
@@ -21,11 +21,11 @@
 part of box2d;
 
 class ContactImpulse {
-  List<num> normalImpulses;
-  List<num> tangentImpulses;
+  List<double> normalImpulses;
+  List<double> tangentImpulses;
 
   ContactImpulse() :
-    normalImpulses = new List<num>(Settings.MAX_MANIFOLD_POINTS),
-    tangentImpulses = new List<num>(Settings.MAX_MANIFOLD_POINTS);
+    normalImpulses = new List<double>(Settings.MAX_MANIFOLD_POINTS),
+    tangentImpulses = new List<double>(Settings.MAX_MANIFOLD_POINTS);
 }
 

--- a/lib/src/collision/distance_output.dart
+++ b/lib/src/collision/distance_output.dart
@@ -25,7 +25,7 @@ class DistanceOutput {
   /** Closest point on shapeB */
   final Vector2 pointB;
 
-  num distance;
+  double distance;
 
   /** number of gjk iterations used */
   int iterations;

--- a/lib/src/collision/distance_proxy.dart
+++ b/lib/src/collision/distance_proxy.dart
@@ -20,7 +20,7 @@ part of box2d;
 class DistanceProxy {
   final List<Vector2> vertices;
   int count;
-  num radius;
+  double radius;
 
   /**
    * Constructs a new DistanceProxy.
@@ -28,7 +28,7 @@ class DistanceProxy {
   DistanceProxy() :
     vertices = new List<Vector2>(Settings.MAX_POLYGON_VERTICES),
     count = 0,
-    radius = 0 {
+    radius = 0.0 {
 
       for(int i = 0; i < vertices.length; ++i)
         vertices[i] = new Vector2.zero();

--- a/lib/src/collision/manifold_point.dart
+++ b/lib/src/collision/manifold_point.dart
@@ -28,10 +28,10 @@ class ManifoldPoint {
   final Vector2 localPoint;
 
   /** The non-penetration impulse. */
-  num normalImpulse;
+  double normalImpulse;
 
   /** The friction impulse. */
-  num tangentImpulse;
+  double tangentImpulse;
 
   /** Unique identifier for a contact point between two shapes. */
   final ContactID id;
@@ -41,8 +41,8 @@ class ManifoldPoint {
    */
   ManifoldPoint() :
     localPoint = new Vector2.zero(),
-    tangentImpulse = 0,
-    normalImpulse = 0,
+    tangentImpulse = 0.0,
+    normalImpulse = 0.0,
     id = new ContactID();
 
   /**

--- a/lib/src/collision/shapes/circle_shape.dart
+++ b/lib/src/collision/shapes/circle_shape.dart
@@ -29,7 +29,7 @@ class CircleShape extends Shape {
    * CircleDef.
    */
   CircleShape() :
-    super(ShapeType.CIRCLE, 0),
+    super(ShapeType.CIRCLE, 0.0),
     position = new Vector2.zero();
 
   /**

--- a/lib/src/collision/shapes/mass_data.dart
+++ b/lib/src/collision/shapes/mass_data.dart
@@ -18,20 +18,20 @@ part of box2d;
 
 class MassData {
   /** The mass of the shape, usually in kilograms. */
-  num mass;
+  double mass;
 
   /** The position of the shape's centroid relative to the shape's origin. */
   Vector2 center;
 
   /** The rotational inertia of the shape about the local origin. */
-  num inertia;
+  double inertia;
 
   /**
    * Constructs a blank mass data.
    */
   MassData() :
-    mass = 0,
-    inertia = 0,
+    mass = 0.0,
+    inertia = 0.0,
     center = new Vector2.zero();
 
   /**

--- a/lib/src/collision/shapes/shape.dart
+++ b/lib/src/collision/shapes/shape.dart
@@ -25,12 +25,12 @@ abstract class Shape {
   int type;
 
   /** Shape radius. */
-  num radius;
+  double radius;
 
   /**
    * Constructs a new shape of unknown type.
    */
-  Shape([int type = ShapeType.UNKNOWN, num radius = 0]) :
+  Shape([int type = ShapeType.UNKNOWN, double radius = 0.0]) :
     type = type,
     radius = radius { }
 

--- a/lib/src/collision/simplex_cache.dart
+++ b/lib/src/collision/simplex_cache.dart
@@ -20,7 +20,7 @@ part of box2d;
 
 class SimplexCache {
   /** length or area */
-  num metric;
+  double metric;
 
   int count;
 
@@ -34,7 +34,7 @@ class SimplexCache {
    * Constructs a new SimplexCache.
    */
   SimplexCache() :
-    metric = 0,
+    metric = 0.0,
     count = 0,
     indexA = new List<int>.generate(3, (i) => Settings.MAX_INTEGER),
     indexB = new List<int>.generate(3, (i) => Settings.MAX_INTEGER);

--- a/lib/src/collision/simplex_vertex.dart
+++ b/lib/src/collision/simplex_vertex.dart
@@ -20,7 +20,7 @@ class SimplexVertex {
   final Vector2 wA; // support point in shapeA
   final Vector2 wB; // support point in shapeB
   final Vector2 w; // wB - wA
-  num a; // barycentric coordinate for closest point
+  double a; // barycentric coordinate for closest point
   int indexA; // wA index
   int indexB; // wB index
 
@@ -28,7 +28,7 @@ class SimplexVertex {
     wA = new Vector2.zero(),
     wB = new Vector2.zero(),
     w = new Vector2.zero(),
-    a = 0,
+    a = 0.0,
     indexA = 0,
     indexB = 0;
 

--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -34,7 +34,7 @@ class Body {
 
   ContactEdge contactList;
 
-  num sleepTime;
+  double sleepTime;
 
   /** User can store what they want in here. */
   Object userData;
@@ -133,7 +133,7 @@ class Body {
         oldCenter = new Vector2.zero(),
         tempCenter = new Vector2.zero(),
 
-        sleepTime = 0,
+        sleepTime = 0.0,
 
         _type = bd.type {
     if (bd.bullet) {
@@ -213,7 +213,7 @@ class Body {
    * If the density is non-zero, this function automatically updates the mass
    * of the body.
    */
-  Fixture createFixtureFromShape(Shape shape, [num density = 0]) {
+  Fixture createFixtureFromShape(Shape shape, [double density = 0.0]) {
     _fixDef.shape = shape;
     _fixDef.density = density;
 

--- a/lib/src/dynamics/body_def.dart
+++ b/lib/src/dynamics/body_def.dart
@@ -29,7 +29,7 @@ class BodyDef {
   /**
    * The world angle of the body in radians.
    */
-  num angle;
+  double angle;
 
   /** User can store whatever they wish in here. */
   Object userData;
@@ -41,7 +41,7 @@ class BodyDef {
   Vector2 linearVelocity;
 
   /** Angular velocity of the body. */
-  num angularVelocity;
+  double angularVelocity;
 
   /**
    * If true, the body will be allowed to rotate. Otherwise, its rotation will
@@ -70,14 +70,14 @@ class BodyDef {
    * parameter can be larger than 1.0 but the damping effect becomes
    * sensitive to the time step when the damping parameter is large.
    */
-  num linearDamping;
+  double linearDamping;
 
   /**
    * Angular damping is used to reduce the angular velocity. The
    * damping parameter can be larger than 1.0 but the damping effect
    * becomes sensitive to time step when the damping parameter is large.
    */
-  num angularDamping;
+  double angularDamping;
 
   /** Is this body initially awake or asleep? */
   bool awake;
@@ -93,13 +93,13 @@ class BodyDef {
     bullet = false,
     type = BodyType.STATIC,
     position = new Vector2.zero(),
-    angle = 0,
-    linearDamping = 0,
-    angularDamping = 0,
+    angle = 0.0,
+    linearDamping = 0.0,
+    angularDamping = 0.0,
     allowSleep = true,
     awake = true,
     fixedRotation = false,
     active = true,
     linearVelocity = new Vector2.zero(),
-    angularVelocity = 0;
+    angularVelocity = 0.0;
 }

--- a/lib/src/dynamics/contacts/contact.dart
+++ b/lib/src/dynamics/contacts/contact.dart
@@ -44,7 +44,7 @@ abstract class Contact {
 
   Manifold manifold;
 
-  num toiCount;
+  int toiCount;
 
   DefaultWorldPool pool;
 

--- a/lib/src/dynamics/contacts/contact_constraint.dart
+++ b/lib/src/dynamics/contacts/contact_constraint.dart
@@ -33,9 +33,9 @@ class ContactConstraint {
 
   int type;
 
-  num radius;
-  num friction;
-  num restitution;
+  double radius;
+  double friction;
+  double restitution;
   int pointCount;
 
   Manifold manifold;

--- a/lib/src/dynamics/contacts/contact_constraint_point.dart
+++ b/lib/src/dynamics/contacts/contact_constraint_point.dart
@@ -20,22 +20,22 @@ class ContactConstraintPoint {
   final Vector2 rA;
   final Vector2 rB;
 
-  num normalImpulse;
-  num tangentImpulse;
-  num normalMass;
-  num tangentMass;
-  num velocityBias;
+  double normalImpulse;
+  double tangentImpulse;
+  double normalMass;
+  double tangentMass;
+  double velocityBias;
 
   /** Constructs a new ContactConstraintPoint. */
   ContactConstraintPoint()
     : localPoint = new Vector2.zero(),
     rA = new Vector2.zero(),
     rB = new Vector2.zero(),
-    normalImpulse = 0,
-    tangentImpulse = 0,
-    normalMass = 0,
-    tangentMass = 0,
-    velocityBias = 0 {}
+    normalImpulse = 0.0,
+    tangentImpulse = 0.0,
+    normalMass = 0.0,
+    tangentMass = 0.0,
+    velocityBias = 0.0 {}
 
   /** Sets this point equal to the given point. */
   void setFrom(ContactConstraintPoint cp) {

--- a/lib/src/dynamics/contacts/contact_solver.dart
+++ b/lib/src/dynamics/contacts/contact_solver.dart
@@ -24,7 +24,7 @@ class ContactSolver {
   /**
    * Ensure a reasonable condition number. For the block solver
    */
-  static const num K_MAX_CONDITION_NUMBER = 100.0;
+  static const double K_MAX_CONDITION_NUMBER = 100.0;
 
   List<ContactConstraint> constraints;
   int constraintCount;

--- a/lib/src/dynamics/contacts/time_of_impact_constraint.dart
+++ b/lib/src/dynamics/contacts/time_of_impact_constraint.dart
@@ -19,7 +19,7 @@ class TimeOfImpactConstraint {
   final Vector2 localNormal;
   final Vector2 localPoint;
   int type;
-  num radius;
+  double radius;
   int pointCount;
   Body bodyA;
   Body bodyB;
@@ -30,7 +30,7 @@ class TimeOfImpactConstraint {
     localNormal = new Vector2.zero(),
     localPoint = new Vector2.zero(),
     type = 0,
-    radius = 0,
+    radius = 0.0,
     pointCount = 0,
     bodyA = null,
     bodyB = null;

--- a/lib/src/dynamics/fixture.dart
+++ b/lib/src/dynamics/fixture.dart
@@ -22,7 +22,7 @@ part of box2d;
 class Fixture {
   final AxisAlignedBox box;
 
-  num density;
+  double density;
 
   Fixture next;
 
@@ -30,9 +30,9 @@ class Fixture {
 
   Shape shape;
 
-  num friction;
+  double friction;
 
-  num restitution;
+  double restitution;
 
   DynamicTreeNode proxy;
 

--- a/lib/src/dynamics/fixture_def.dart
+++ b/lib/src/dynamics/fixture_def.dart
@@ -33,17 +33,17 @@ class FixtureDef {
   /**
    * The friction coefficient, usually in the range [0,1].
    */
-  num friction;
+  double friction;
 
   /**
    * The restitution (elasticity) usually in the range [0,1].
    */
-  num restitution;
+  double restitution;
 
   /**
    * The density, usually in kg/m^2
    */
-  num density;
+  double density;
 
   /**
    * A sensor shape collects contact information but never generates a collision
@@ -63,8 +63,8 @@ class FixtureDef {
     shape = null,
     userData = null,
     friction = 0.2,
-    restitution = 0,
-    density = 0,
+    restitution = 0.0,
+    density = 0.0,
     filter = new Filter(),
     isSensor = false {
     // Setup the filter.

--- a/lib/src/dynamics/joints/constant_volume_joint.dart
+++ b/lib/src/dynamics/joints/constant_volume_joint.dart
@@ -23,25 +23,25 @@ part of box2d;
 
 class ConstantVolumeJoint extends Joint {
   List<Body> bodies;
-  List<num> targetLengths;
-  num targetVolume;
+  List<double> targetLengths;
+  double targetVolume;
 
   List<Vector2> normals;
 
   TimeStep step;
 
-  num _impulse;
+  double _impulse;
 
   World _world;
 
   List<DistanceJoint> distanceJoints;
 
-  num frequencyHz;
-  num dampingRatio;
+  double frequencyHz;
+  double dampingRatio;
 
   ConstantVolumeJoint(this._world, ConstantVolumeJointDef def) :
     super(def),
-    _impulse = 0 {
+    _impulse = 0.0 {
     if (def.bodies.length <= 2) {
       throw new ArgumentError(
           "You cannot create a constant volume joint with less than three "
@@ -52,7 +52,7 @@ class ConstantVolumeJoint extends Joint {
     // in the growable array in the definition.
     bodies = new List.from(def.bodies);
 
-    targetLengths = new List<num>(bodies.length);
+    targetLengths = new List<double>(bodies.length);
     for (int i = 0; i < targetLengths.length; ++i) {
       final int next = (i == targetLengths.length - 1) ? 0 : i + 1;
       Vector2 temp = new Vector2.copy(bodies[i].worldCenter);

--- a/lib/src/dynamics/joints/constant_volume_joint_def.dart
+++ b/lib/src/dynamics/joints/constant_volume_joint_def.dart
@@ -20,8 +20,8 @@
 part of box2d;
 
 class ConstantVolumeJointDef extends JointDef {
-  num frequencyHz;
-  num dampingRatio;
+  double frequencyHz;
+  double dampingRatio;
 
   List<Body> bodies;
   List<DistanceJoint> joints;

--- a/lib/src/dynamics/joints/distance_joint.dart
+++ b/lib/src/dynamics/joints/distance_joint.dart
@@ -24,15 +24,15 @@ class DistanceJoint extends Joint {
   final Vector2 localAnchor1;
   final Vector2 localAnchor2;
   final Vector2 u;
-  num impulse;
+  double impulse;
 
   /** Effective mass for the constraint. */
-  num mass;
-  num length;
-  num frequencyHz;
-  num dampingRatio;
-  num gamma;
-  num bias;
+  double mass;
+  double length;
+  double frequencyHz;
+  double dampingRatio;
+  double gamma;
+  double bias;
 
   DistanceJoint(DistanceJointDef def) :
     super(def),
@@ -59,7 +59,7 @@ class DistanceJoint extends Joint {
     argOut.y = impulse * u.y * inv_dt;
   }
 
-  num getReactionTorque(num inv_dt) {
+  double getReactionTorque(num inv_dt) {
     return 0.0;
   }
 

--- a/lib/src/dynamics/joints/distance_joint_def.dart
+++ b/lib/src/dynamics/joints/distance_joint_def.dart
@@ -31,17 +31,17 @@ class DistanceJointDef extends JointDef {
   final Vector2 localAnchorB;
 
   /** The equilibrium length between the anchor points. */
-  num length;
+  double length;
 
   /**
    * The mass-spring-damper frequency in Hertz.
    */
-  num frequencyHz;
+  double frequencyHz;
 
   /**
    * The damping ratio. 0 = no damping, 1 = critical damping.
    */
-  num dampingRatio;
+  double dampingRatio;
 
   DistanceJointDef() :
     super(),

--- a/lib/src/dynamics/joints/friction_joint.dart
+++ b/lib/src/dynamics/joints/friction_joint.dart
@@ -19,9 +19,9 @@ class FrictionJoint extends Joint {
   final Vector2 _localAnchorB;
 
   Vector2 _linearImpulse;
-  num _angularImpulse;
-  num _maxForce;
-  num _maxTorque;
+  double _angularImpulse;
+  double _maxForce;
+  double _maxTorque;
 
   FrictionJoint(FrictionJointDef def)
       : _localAnchorA = new Vector2.copy(def.localAnchorA),
@@ -44,21 +44,21 @@ class FrictionJoint extends Joint {
     argOut.setFrom(_linearImpulse).mulLocal(inv_dt);
   }
 
-  num getReactionTorque(num inv_dt) => inv_dt * _angularImpulse;
+  double getReactionTorque(num inv_dt) => inv_dt * _angularImpulse;
 
   void set maxForce(num force) {
     assert(force >= 0.0);
     _maxForce = force;
   }
 
-  num get maxForce => _maxForce;
+  double get maxForce => _maxForce;
 
   void set maxTorque(num torque) {
     assert(torque >= 0.0);
     _maxTorque = torque;
   }
 
-  num get maxTorque => _maxTorque;
+  double get maxTorque => _maxTorque;
 
   void initVelocityConstraints(TimeStep step) {
     // Compute the effective mass matrix.

--- a/lib/src/dynamics/joints/friction_joint_def.dart
+++ b/lib/src/dynamics/joints/friction_joint_def.dart
@@ -22,10 +22,10 @@ class FrictionJointDef extends JointDef {
   final Vector2 localAnchorB;
 
   /** The maximum friction force in N. */
-  num maxForce;
+  double maxForce;
 
   /** The maximum friction torque in N-m. */
-  num maxTorque;
+  double maxTorque;
 
   FrictionJointDef()
       : super(),

--- a/lib/src/dynamics/joints/joint.dart
+++ b/lib/src/dynamics/joints/joint.dart
@@ -40,10 +40,10 @@ class Joint {
   final Vector2 localCenterA;
   final Vector2 localCenterB;
 
-  num invMassA;
-  num invIA;
-  num invMassB;
-  num invIB;
+  double invMassA;
+  double invIA;
+  double invMassB;
+  double invIB;
 
   Joint(JointDef def) :
     type = def.type,
@@ -108,7 +108,7 @@ class Joint {
   void getReactionForce(num inv_dt, Vector2 argOut) { }
 
   /** Get the reaction torque on body2 in N*m. */
-  num getReactionTorque(num inv_dt) { }
+  double getReactionTorque(num inv_dt) { }
 
   /** Short-cut function to determine if either body is inactive. */
   bool get active => bodyA.active && bodyB.active;

--- a/lib/src/dynamics/joints/revolute_joint.dart
+++ b/lib/src/dynamics/joints/revolute_joint.dart
@@ -29,27 +29,27 @@ class RevoluteJoint extends Joint {
 
   final Vector3 impulse;
 
-  num _motorImpulse;
+  double _motorImpulse;
 
   // Effective mass for point-to-point constraint.
   final Matrix33 mass;
 
   // Effective mass for motor/limit angular constraint.
-  num motorMass;
+  double motorMass;
 
   bool _enableMotor;
 
-  num _maxMotorTorque;
+  double _maxMotorTorque;
 
-  num _motorSpeed;
+  double _motorSpeed;
 
   bool _enableLimit;
 
-  num referenceAngle;
+  double referenceAngle;
 
   /** Limits on the relative rotation of the joint. */
-  num lowerAngle;
-  num upperAngle;
+  double lowerAngle;
+  double upperAngle;
 
   int limitState;
 
@@ -58,13 +58,13 @@ class RevoluteJoint extends Joint {
       localAnchor1 = new Vector2.zero(),
       localAnchor2 = new Vector2.zero(),
       impulse = new Vector3.zero(),
-      _motorImpulse = 0,
+      _motorImpulse = 0.0,
       mass = new Matrix33() {
     localAnchor1.setFrom(def.localAnchorA);
     localAnchor2.setFrom(def.localAnchorB);
     referenceAngle = def.referenceAngle;
 
-    _motorImpulse = 0;
+    _motorImpulse = 0.0;
 
     lowerAngle = def.lowerAngle;
     upperAngle = def.upperAngle;

--- a/lib/src/dynamics/joints/revolute_joint_def.dart
+++ b/lib/src/dynamics/joints/revolute_joint_def.dart
@@ -42,7 +42,7 @@ class RevoluteJointDef extends JointDef {
   /**
    *  The body2 angle minus body1 angle in the reference state (radians).
    */
-  num referenceAngle;
+  double referenceAngle;
 
   /**
    *  A flag to enable joint limits.
@@ -52,12 +52,12 @@ class RevoluteJointDef extends JointDef {
   /**
    *  The lower angle for the joint limit (radians).
    */
-  num lowerAngle;
+  double lowerAngle;
 
   /**
    *  The upper angle for the joint limit (radians).
    */
-  num upperAngle;
+  double upperAngle;
 
   /**
    *  A flag to enable the joint motor.
@@ -67,13 +67,13 @@ class RevoluteJointDef extends JointDef {
   /**
    *  The desired motor speed. Usually in radians per second.
    */
-  num motorSpeed;
+  double motorSpeed;
 
   /**
    *  The maximum motor torque used to achieve the desired motor speed.
    *  Usually in N-m.
    */
-  num maxMotorTorque;
+  double maxMotorTorque;
 
   RevoluteJointDef() :
     super(),

--- a/lib/src/dynamics/timestep.dart
+++ b/lib/src/dynamics/timestep.dart
@@ -20,21 +20,21 @@ part of box2d;
 
 class TimeStep {
   TimeStep() :
-      dt = 0,
-      inv_dt = 0,
-      dtRatio = 0,
+      dt = 0.0,
+      inv_dt = 0.0,
+      dtRatio = 0.0,
       velocityIterations = 0,
       positionIterations = 0,
       warmStarting = true;
 
   /** time step */
-  num dt;
+  double dt;
 
   /** inverse time step (0 if dt == 0). */
-  num inv_dt;
+  double inv_dt;
 
   /** dt * inv_dt0 */
-  num dtRatio;
+  double dtRatio;
 
   int velocityIterations;
 

--- a/lib/src/dynamics/world.dart
+++ b/lib/src/dynamics/world.dart
@@ -54,7 +54,7 @@ class World {
    * This is used to compute the time step ratio to
    * support a variable time step.
    */
-  num _inverseTimestep;
+  double _inverseTimestep;
 
   /**
    * This is for debugging the solver.
@@ -113,7 +113,7 @@ class World {
 
     _flags = CLEAR_FORCES,
 
-    _inverseTimestep = 0,
+    _inverseTimestep = 0.0,
 
     _contactStacks = new List<List<ContactRegister>>(ShapeType.TYPE_COUNT),
 
@@ -486,7 +486,7 @@ class World {
    * param positionIterations
    *   for the position constraint solver.
    */
-  void step(num dt, int velocityIterations, int positionIterations) {
+  void step(double dt, int velocityIterations, int positionIterations) {
 
     // If new fixtures were added, we need to find the new contacts.
     if ((_flags & NEW_FIXTURE) == NEW_FIXTURE) {


### PR DESCRIPTION
The current version is not running in darts checked mode because many attributes are typed as num an contain as integers as well as doubles as values but some attributes are typed as doubles.
So when one class which num-attributes gets in touch with another class with more strictly typed double-attributes there will be conflicts.

To be consistent I changed all attributes to be typed as double. In terms of BC this is a little break but the current code does not work in checked mode anyway. With checked mode disabled the BC break is not noticeable.
