### PR TITLE
Remove use of call chaining

### DIFF
--- a/example/demos/racer/tire.dart
+++ b/example/demos/racer/tire.dart
@@ -44,11 +44,11 @@ class Tire {
   }
 
   void updateFriction() {
-    final Vector2 impulse = _lateralVelocity.scale(-_body.mass);
+    final Vector2 impulse = _lateralVelocity..scale(-_body.mass);
     if (impulse.length > _maxLateralImpulse) {
       impulse.scale(_maxLateralImpulse / impulse.length);
     }
-    _body.applyLinearImpulse(impulse.scale(_currentTraction),
+    _body.applyLinearImpulse(impulse..scale(_currentTraction),
                              _body.worldCenter);
     _body.applyAngularImpulse(
         0.1 * _currentTraction * _body.inertia * (-_body.angularVelocity));
@@ -58,7 +58,7 @@ class Tire {
     currentForwardNormal.normalize();
     final double dragForceMagnitude = -2 * currentForwardSpeed;
     _body.applyForce(
-        currentForwardNormal.scale(_currentTraction * dragForceMagnitude),
+        currentForwardNormal..scale(_currentTraction * dragForceMagnitude),
         _body.worldCenter);
   }
 
@@ -81,7 +81,7 @@ class Tire {
     }
 
     if (force.abs() > 0) {
-      _body.applyForce(currentForwardNormal.scale(_currentTraction * force),
+      _body.applyForce(currentForwardNormal..scale(_currentTraction * force),
                        _body.worldCenter);
     }
   }
@@ -108,12 +108,12 @@ class Tire {
 
   Vector2 get _lateralVelocity {
     final Vector2 currentRightNormal = _body.getWorldVector2(_worldLeft);
-    return currentRightNormal.scale(currentRightNormal.dot(_body.linearVelocity));
+    return currentRightNormal..scale(currentRightNormal.dot(_body.linearVelocity));
   }
 
   Vector2 get _forwardVelocity {
     final Vector2 currentForwardNormal = _body.getWorldVector2(_worldUp);
-    return currentForwardNormal.scale(currentForwardNormal.dot(_body.linearVelocity));
+    return currentForwardNormal..scale(currentForwardNormal.dot(_body.linearVelocity));
   }
 
   Body _body;

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -231,8 +231,8 @@ class DynamicTree {
         // two children.
         deltaOne.setFrom(childOne.box.center);
         deltaTwo.setFrom(childTwo.box.center);
-        deltaOne.sub(center).absolute();
-        deltaTwo.sub(center).absolute();
+        deltaOne..sub(center)..absolute();
+        deltaTwo..sub(center)..absolute();
 
         num normOne = deltaOne.x + deltaOne.y;
         num normTwo = deltaTwo.x + deltaTwo.y;

--- a/lib/src/collision/collision.dart
+++ b/lib/src/collision/collision.dart
@@ -139,8 +139,8 @@ class Collision {
       // Find intersection point of edge and plane
       double interp = distance0 / (distance0 - distance1);
       // vOut[numOut].v = vIn[0].v + interp * (vIn[1].v - vIn[0].v);
-      vOut[numOut].v.setFrom(vIn[1].v).
-          sub(vIn[0].v).scale(interp).add(vIn[0].v);
+      vOut[numOut].v..setFrom(vIn[1].v)..
+          sub(vIn[0].v)..scale(interp)..add(vIn[0].v);
       final ClipVertex vin = (distance0 > 0.0 ? vIn[0] : vIn[1]);
       vOut[numOut].id.setFrom(vin.id);
       ++numOut;
@@ -278,7 +278,7 @@ class Collision {
     } else {
       // Vector2 faceCenter = 0.5 * (v1 + v2);
       // (temp is faceCenter)
-      final Vector2 fc = (v1 + v2).scale(0.5);
+      final Vector2 fc = (v1 + v2)..scale(0.5);
 
       final Vector2 t = cLocal - fc;
       final Vector2 norm = normals[vertIndex1];
@@ -515,14 +515,14 @@ class Collision {
     v11.setFrom(vertices1[edge1]);
     v12.setFrom(edge1 + 1 < count1 ? vertices1[edge1 + 1] : vertices1[0]);
 
-    localTangent.setFrom(v12).sub(v11);
+    localTangent..setFrom(v12)..sub(v11);
     localTangent.normalize();
 
     // Vector2 localNormal = Cross(dv, 1.0);
     localTangent.scaleOrthogonalInto(-1.0, localNormal);
 
     // Vector2 planePoint = 0.5 * (v11 + v12)
-    planePoint.setFrom(v11).add(v12).scale(.5);
+    planePoint..setFrom(v11)..add(v12)..scale(.5);
 
     // Vector2 sideNormal = Mul(xf1.rotation, v12 - v11);
     xf1.rotation.transformed(localTangent, tangent);

--- a/lib/src/collision/distance.dart
+++ b/lib/src/collision/distance.dart
@@ -122,17 +122,17 @@ class Distance {
       SimplexVertex vertex = vertices[simplex.count];
 
       transformA.rotation.transposed().transformed(
-          searchDirection.negate(), temp);
+          searchDirection..negate(), temp);
       vertex.indexA = proxyA.getSupport(temp);
       Transform.mulToOut(transformA, proxyA.vertices[vertex.indexA],
           vertex.wA);
       // Vec2 wBLocal;
       transformB.rotation.transposed().transformed(
-          searchDirection.negate(), temp);
+          searchDirection..negate(), temp);
       vertex.indexB = proxyB.getSupport(temp);
       Transform.mulToOut(transformB, proxyB.vertices[vertex.indexB],
           vertex.wB);
-      vertex.w.setFrom(vertex.wB).sub(vertex.wA);
+      vertex.w..setFrom(vertex.wB)..sub(vertex.wA);
 
       // Iteration count is equated to the number of support point calls.
       ++iter;
@@ -174,16 +174,16 @@ class Distance {
         // Shapes are still no overlapped.
         // Move the witness points to the outer surface.
         output.distance -= rA + rB;
-        normal.setFrom(output.pointB).sub(output.pointA);
+        normal..setFrom(output.pointB)..sub(output.pointA);
         normal.normalize();
-        temp.setFrom(normal).scale(rA);
+        temp..setFrom(normal)..scale(rA);
         output.pointA.add(temp);
-        temp.setFrom(normal).scale(rB);
+        temp..setFrom(normal)..scale(rB);
         output.pointB.sub(temp);
       } else {
         // Shapes are overlapped when radii are considered.
         // Move the witness points to the middle.
-        output.pointA.add(output.pointB).scale(.5);
+        output.pointA..add(output.pointB)..scale(.5);
         output.pointB.setFrom(output.pointA);
         output.distance = 0.0;
       }

--- a/lib/src/collision/shapes/circle_shape.dart
+++ b/lib/src/collision/shapes/circle_shape.dart
@@ -50,7 +50,7 @@ class CircleShape extends Shape {
     transform.rotation.transformed(position, center);
     center.add(transform.position);
 
-    Vector2 d = center.sub(point).negate();
+    Vector2 d = center..sub(point)..negate();
     return d.dot(d) <= radius * radius;
   }
 
@@ -60,11 +60,11 @@ class CircleShape extends Shape {
     transform.rotation.transformed(position, center);
     center.add(transform.position);
 
-    Vector2 s = input.p1.sub(center);
+    Vector2 s = input.p1..sub(center);
     double b = s.dot(s) - (radius * radius);
 
     // Solve quadratic equation
-    Vector2 r = input.p2.sub(input.p1);
+    Vector2 r = input.p2..sub(input.p1);
     double c = s.dot(r);
     double rr = r.dot(r);
     double sigma = c * c - rr * b;
@@ -76,7 +76,7 @@ class CircleShape extends Shape {
     if (0.0 <= a && a <= input.maxFraction * rr) {
       a /= rr;
       output.fraction = a;
-      output.normal = (r.scale(a)).add(s);
+      output.normal = (r..scale(a))..add(s);
       output.normal.normalize();
       return true;
     }

--- a/lib/src/collision/shapes/polygon_shape.dart
+++ b/lib/src/collision/shapes/polygon_shape.dart
@@ -118,7 +118,7 @@ class PolygonShape extends Shape {
     for (int i = 0; i < vertexCount; ++i) {
       final int i1 = i;
       final int i2 = i + 1 < vertexCount ? i + 1 : 0;
-      edge.setFrom(vertices[i2]).sub(vertices[i1]);
+      edge..setFrom(vertices[i2])..sub(vertices[i1]);
 
       assert (edge.length2 > Settings.EPSILON * Settings.EPSILON);
       edge.scaleOrthogonalInto(-1.0, normals[i]);
@@ -174,11 +174,11 @@ class PolygonShape extends Shape {
     vertexCount = 2;
     vertices[0].setFrom(v1);
     vertices[1].setFrom(v2);
-    centroid.setFrom(v1).add(v2).scale(0.5);
-    normals[0].setFrom(v2).sub(v1);
+    centroid..setFrom(v1)..add(v2)..scale(0.5);
+    normals[0]..setFrom(v2)..sub(v1);
     normals[0].scaleOrthogonalInto(-1.0, normals[0]);
     normals[0].normalize();
-    normals[1].setFrom(normals[0]).negate();
+    normals[1]..setFrom(normals[0])..negate();
   }
 
   /**
@@ -187,13 +187,13 @@ class PolygonShape extends Shape {
   bool testPoint(Transform xf, Vector2 p) {
     Vector2 pLocal = new Vector2.zero();
 
-    pLocal.setFrom(p).sub(xf.position);
+    pLocal..setFrom(p)..sub(xf.position);
     xf.rotation.transposed().transformed(pLocal, pLocal);
 
     Vector2 temp = new Vector2.zero();
 
     for (int i = 0; i < vertexCount; ++i) {
-      temp.setFrom(pLocal).sub(vertices[i]);
+      temp..setFrom(pLocal)..sub(vertices[i]);
       if (normals[i].dot(temp) > 0) return false;
     }
 
@@ -205,13 +205,13 @@ class PolygonShape extends Shape {
     Vector2 p1 = new Vector2.zero();
     Vector2 p2 = new Vector2.zero();
 
-    p1.setFrom(input.p1).sub(xf.position);
+    p1..setFrom(input.p1)..sub(xf.position);
     xf.rotation.transposed().transformed(p1, p1);
 
-    p2.setFrom(input.p2).sub(xf.position);
+    p2..setFrom(input.p2)..sub(xf.position);
     xf.rotation.transposed().transformed(p2, p2);
 
-    Vector2 d = p2.sub(p1);
+    Vector2 d = p2..sub(p1);
 
     double lower = 0.0;
     double upper = input.maxFraction;
@@ -222,7 +222,7 @@ class PolygonShape extends Shape {
       Vector2 normal = normals[i];
       Vector2 vertex = vertices[i];
 
-      Vector2 temp = vertex.sub(p1);
+      Vector2 temp = vertex..sub(p1);
       double numerator = normal.dot(temp);
       double denominator = normal.dot(d);
 
@@ -290,7 +290,7 @@ class PolygonShape extends Shape {
     double area = 0.0;
 
     if (count == 2) {
-      out.setFrom(vs[0]).add(vs[1]).scale(.5);
+      out..setFrom(vs[0])..add(vs[1])..scale(.5);
       return;
     }
 
@@ -310,8 +310,8 @@ class PolygonShape extends Shape {
       final Vector2 p2 = vs[i];
       final Vector2 p3 = i + 1 < count ? vs[i + 1] : vs[0];
 
-      e1.setFrom(p2).sub(p1);
-      e2.setFrom(p3).sub(p1);
+      e1..setFrom(p2)..sub(p1);
+      e2..setFrom(p3)..sub(p1);
 
       final double D = e1.cross(e2);
 
@@ -319,7 +319,7 @@ class PolygonShape extends Shape {
       area += triangleArea;
 
       // Area weighted centroid
-      out.add(p1).add(p2).add(p3).scale(triangleArea * inv3);
+      out..add(p1)..add(p2)..add(p3)..scale(triangleArea * inv3);
     }
 
     // Centroid
@@ -360,7 +360,7 @@ class PolygonShape extends Shape {
     // A line segment has zero mass.
     if (vertexCount == 2) {
       // massData.center = 0.5 * (vertices[0] + vertices[1]);
-      massData.center.setFrom(vertices[0]).add(vertices[1]).scale(0.5);
+      massData.center..setFrom(vertices[0])..add(vertices[1])..scale(0.5);
       massData.mass = 0.0;
       massData.inertia = 0.0;
       return;

--- a/lib/src/collision/simplex.dart
+++ b/lib/src/collision/simplex.dart
@@ -54,7 +54,7 @@ class Simplex {
       Vector2 wBLocal = proxyB.vertices[v.indexB];
       Transform.mulToOut(transformA, wALocal, v.wA);
       Transform.mulToOut(transformB, wBLocal, v.wB);
-      v.w.setFrom(v.wB).sub(v.wA);
+      v.w..setFrom(v.wB)..sub(v.wA);
       v.a = 0.0;
     }
 
@@ -79,7 +79,7 @@ class Simplex {
       Vector2 wBLocal = proxyB.vertices[0];
       Transform.mulToOut(transformA, wALocal, v.wA);
       Transform.mulToOut(transformB, wBLocal, v.wB);
-      v.w.setFrom(v.wB).sub(v.wA);
+      v.w..setFrom(v.wB)..sub(v.wA);
       count = 1;
     }
   }
@@ -97,12 +97,12 @@ class Simplex {
   void getSearchDirection(Vector2 out) {
     switch (count) {
       case 1:
-        out.setFrom(v1.w).negate();
+        out..setFrom(v1.w)..negate();
         return;
       case 2:
-        e12.setFrom(v2.w).sub(v1.w);
+        e12..setFrom(v2.w)..sub(v1.w);
         // use out for a temp variable real quick
-        out.setFrom(v1.w).negate();
+        out..setFrom(v1.w)..negate();
         double sgn = e12.cross(out);
 
         if (sgn > 0.0) {
@@ -134,8 +134,8 @@ class Simplex {
         out.setFrom(v1.w);
         return;
       case 2:
-        case22.setFrom(v2.w).scale(v2.a);
-        case2.setFrom(v1.w).scale(v1.a).add(case22);
+        case22..setFrom(v2.w)..scale(v2.a);
+        case2..setFrom(v1.w)..scale(v1.a)..add(case22);
         out.setFrom(case2);
         return;
       case 3:
@@ -161,19 +161,19 @@ class Simplex {
         break;
 
       case 2:
-        case2.setFrom(v1.wA).scale(v1.a);
-        pA.setFrom(v2.wA).scale(v2.a).add(case2);
-        case2.setFrom(v1.wB).scale(v1.a);
-        pB.setFrom(v2.wB).scale(v2.a).add(case2);
+        case2..setFrom(v1.wA)..scale(v1.a);
+        pA..setFrom(v2.wA)..scale(v2.a)..add(case2);
+        case2..setFrom(v1.wB)..scale(v1.a);
+        pB..setFrom(v2.wB)..scale(v2.a)..add(case2);
 
         break;
 
       case 3:
-        pA.setFrom(v1.wA).scale(v1.a);
-        case3.setFrom(v2.wA).scale(v2.a);
-        case33.setFrom(v3.wA).scale(v3.a);
-        pA.add(case3).add(case33);
-        pB.setFrom(pA);
+        pA..setFrom(v1.wA)..scale(v1.a);
+        case3..setFrom(v2.wA)..scale(v2.a);
+        case33..setFrom(v3.wA)..scale(v3.a);
+        pA..add(case3)..add(case33);
+        pB..setFrom(pA);
         break;
 
       default:
@@ -195,8 +195,8 @@ class Simplex {
         return MathBox.distance(v1.w, v2.w);
 
       case 3:
-        case3.setFrom(v2.w).sub(v1.w);
-        case33.setFrom(v3.w).sub(v1.w);
+        case3..setFrom(v2.w)..sub(v1.w);
+        case33..setFrom(v3.w)..sub(v1.w);
         return case3.cross(case33);
 
       default:
@@ -211,7 +211,7 @@ class Simplex {
   void solve2() {
     Vector2 w1 = v1.w;
     Vector2 w2 = v2.w;
-    e12.setFrom(w2).sub(w1);
+    e12..setFrom(w2)..sub(w1);
 
     // w1 region
     double d12_2 = -w1.dot(e12);
@@ -253,21 +253,21 @@ class Simplex {
     Vector2 w3 = v3.w;
 
     // Edge12
-    e12.setFrom(w2).sub(w1);
+    e12..setFrom(w2)..sub(w1);
     double w1e12 = w1.dot(e12);
     double w2e12 = w2.dot(e12);
     double d12_1 = w2e12;
     double d12_2 = -w1e12;
 
     // Edge13
-    e13.setFrom(w3).sub(w1);
+    e13..setFrom(w3)..sub(w1);
     double w1e13 = w1.dot(e13);
     double w3e13 = w3.dot(e13);
     double d13_1 = w3e13;
     double d13_2 = -w1e13;
 
     // Edge23
-    e23.setFrom(w3).sub(w2);
+    e23..setFrom(w3)..sub(w2);
     double w2e23 = w2.dot(e23);
     double w3e23 = w3.dot(e23);
     double d23_1 = w3e23;

--- a/lib/src/collision/time_of_impact.dart
+++ b/lib/src/collision/time_of_impact.dart
@@ -276,7 +276,7 @@ class SeparationFunction {
       localPointB.setFrom(proxyB.vertices[cache.indexB[0]]);
       Transform.mulToOut(xfa, localPointA, pointA);
       Transform.mulToOut(xfb, localPointB, pointB);
-      axis.setFrom(pointB).sub(pointA);
+      axis..setFrom(pointB)..sub(pointA);
       double s = axis.normalizeLength();
       return s;
     } else if (cache.indexA[0] == cache.indexA[1]) {
@@ -286,7 +286,7 @@ class SeparationFunction {
       localPointB1.setFrom(proxyB.vertices[cache.indexB[0]]);
       localPointB2.setFrom(proxyB.vertices[cache.indexB[1]]);
 
-      temp.setFrom(localPointB2).sub(localPointB1);
+      temp..setFrom(localPointB2)..sub(localPointB1);
       temp.scaleOrthogonalInto(-1.0, axis);
       axis.normalize();
 
@@ -349,7 +349,7 @@ class SeparationFunction {
     switch (type) {
       case SeparationType.POINTS:
         xfa.rotation.transposed().transformed(axis, axisA);
-        xfb.rotation.transposed().transformed(axis.negate(),
+        xfb.rotation.transposed().transformed(axis..negate(),
             axisB);
         axis.negate();
 
@@ -362,7 +362,7 @@ class SeparationFunction {
         Transform.mulToOut(xfa, localPointA, pointA);
         Transform.mulToOut(xfb, localPointB, pointB);
 
-        double separation = pointB.sub(pointA).dot(axis);
+        double separation = (pointB..sub(pointA)).dot(axis);
         return separation;
 
       case SeparationType.FACE_A:
@@ -379,7 +379,7 @@ class SeparationFunction {
         localPointB.setFrom(proxyB.vertices[indexes[1]]);
         Transform.mulToOut(xfb, localPointB, pointB);
 
-        double separation = pointB.sub(pointA).dot(normal);
+        double separation = (pointB..sub(pointA)).dot(normal);
         return separation;
 
       case SeparationType.FACE_B:
@@ -387,7 +387,7 @@ class SeparationFunction {
         Transform.mulToOut(xfb, localPoint, pointB);
 
         xfa.rotation.transposed().transformed(
-            normal.negate(), axisA);
+            normal..negate(), axisA);
         normal.negate();
 
         indexes[1] = -1;
@@ -396,7 +396,7 @@ class SeparationFunction {
         localPointA.setFrom(proxyA.vertices[indexes[0]]);
         Transform.mulToOut(xfa, localPointA, pointA);
 
-        double separation = pointA.sub(pointB).dot(normal);
+        double separation = (pointA..sub(pointB)).dot(normal);
         return separation;
 
       default:
@@ -414,7 +414,7 @@ class SeparationFunction {
     switch (type) {
       case SeparationType.POINTS:
         xfa.rotation.transposed().transformed(axis, axisA);
-        xfb.rotation.transposed().transformed(axis.negate(),
+        xfb.rotation.transposed().transformed(axis..negate(),
             axisB);
         axis.negate();
 
@@ -424,7 +424,7 @@ class SeparationFunction {
         Transform.mulToOut(xfa, localPointA, pointA);
         Transform.mulToOut(xfb, localPointB, pointB);
 
-        double separation = pointB.sub(pointA).dot(axis);
+        double separation = (pointB..sub(pointA)).dot(axis);
         return separation;
 
       case SeparationType.FACE_A:
@@ -437,20 +437,20 @@ class SeparationFunction {
 
         localPointB.setFrom(proxyB.vertices[indexB]);
         Transform.mulToOut(xfb, localPointB, pointB);
-        double separation = pointB.sub(pointA).dot(normal);
+        double separation = (pointB..sub(pointA)).dot(normal);
         return separation;
 
       case SeparationType.FACE_B:
         xfb.rotation.transformed(axis, normal);
         Transform.mulToOut(xfb, localPoint, pointB);
 
-        xfa.rotation.transposed().transformed(normal.negate(), axisA);
+        xfa.rotation.transposed().transformed(normal..negate(), axisA);
         normal.negate();
 
         localPointA.setFrom(proxyA.vertices[indexA]);
         Transform.mulToOut(xfa, localPointA, pointA);
 
-        double separation = pointA.sub(pointB).dot(normal);
+        double separation = (pointA..sub(pointB)).dot(normal);
         return separation;
 
       default:

--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -650,7 +650,7 @@ class Body {
   }
 
   void getLinearVelocityFromWorldPointToOut(Vector2 worldPoint, Vector2 out) {
-    out.setFrom(worldPoint).sub(sweep.center);
+    out..setFrom(worldPoint)..sub(sweep.center);
     out.scaleOrthogonalInto(_angularVelocity, out);
     out.add(_linearVelocity);
   }

--- a/lib/src/dynamics/contacts/contact_solver.dart
+++ b/lib/src/dynamics/contacts/contact_solver.dart
@@ -353,18 +353,18 @@ class ContactSolver {
           if (x.x >= 0.0 && x.y >= 0.0) {
             // Resubstitute for the incremental impulse
             //Vector2 d = x - a;
-            d.setFrom(x).sub(a);
+            d..setFrom(x)..sub(a);
 
             // Apply incremental impulse
             // Vector2 P1 = d.x * normal;
             // Vector2 P2 = d.y * normal;
-            P1.setFrom(c.normal).scale(d.x);
-            P2.setFrom(c.normal).scale(d.y);
+            P1..setFrom(c.normal)..scale(d.x);
+            P2..setFrom(c.normal)..scale(d.y);
 
-            temp1.setFrom(P1).add(P2);
-            temp2.setFrom(temp1).scale(invMassA);
+            temp1..setFrom(P1)..add(P2);
+            temp2..setFrom(temp1)..scale(invMassA);
             vA.sub(temp2);
-            temp2.setFrom(temp1).scale(invMassB);
+            temp2..setFrom(temp1)..scale(invMassB);
             vB.add(temp2);
 
             wA -= invIA * (cp1.rA.cross(P1) + cp2.rA.cross(P2));
@@ -384,16 +384,16 @@ class ContactSolver {
 
           if (x.x >= 0.0 && vn2 >= 0.0) {
             // Resubstitute for the incremental impulse
-            d.setFrom(x).sub(a);
+            d..setFrom(x)..sub(a);
 
             // Apply incremental impulse
-            P1.setFrom(c.normal).scale(d.x);
-            P2.setFrom(c.normal).scale(d.y);
+            P1..setFrom(c.normal)..scale(d.x);
+            P2..setFrom(c.normal)..scale(d.y);
 
-            temp1.setFrom(P1).add(P2);
-            temp2.setFrom(temp1).scale(invMassA);
+            temp1..setFrom(P1)..add(P2);
+            temp2..setFrom(temp1)..scale(invMassA);
             vA.sub(temp2);
-            temp2.setFrom(temp1).scale(invMassB);
+            temp2..setFrom(temp1)..scale(invMassB);
             vB.add(temp2);
 
             wA -= invIA * (cp1.rA.cross(P1) + cp2.rA.cross(P2));
@@ -413,16 +413,16 @@ class ContactSolver {
 
           if (x.y >= 0.0 && vn1 >= 0.0) {
             // Resubstitute for the incremental impulse
-            d.setFrom(x).sub(a);
+            d..setFrom(x)..sub(a);
 
             // Apply incremental impulse
-            P1.setFrom(c.normal).scale(d.x);
-            P2.setFrom(c.normal).scale(d.y);
+            P1..setFrom(c.normal)..scale(d.x);
+            P2..setFrom(c.normal)..scale(d.y);
 
-            temp1.setFrom(P1).add(P2);
-            temp2.setFrom(temp1).scale(invMassA);
+            temp1..setFrom(P1)..add(P2);
+            temp2..setFrom(temp1)..scale(invMassA);
             vA.sub(temp2);
-            temp2.setFrom(temp1).scale(invMassB);
+            temp2..setFrom(temp1)..scale(invMassB);
             vB.add(temp2);
 
             wA -= invIA * (cp1.rA.cross(P1) + cp2.rA.cross(P2));
@@ -442,16 +442,16 @@ class ContactSolver {
 
           if (vn1 >= 0.0 && vn2 >= 0.0) {
             // Resubstitute for the incremental impulse
-            d.setFrom(x).sub(a);
+            d..setFrom(x)..sub(a);
 
             // Apply incremental impulse
-            P1.setFrom(c.normal).scale(d.x);
-            P2.setFrom(c.normal).scale(d.y);
+            P1..setFrom(c.normal)..scale(d.x);
+            P2..setFrom(c.normal)..scale(d.y);
 
-            temp1.setFrom(P1).add(P2);
-            temp2.setFrom(temp1).scale(invMassA);
+            temp1..setFrom(P1)..add(P2);
+            temp2..setFrom(temp1)..scale(invMassA);
             vA.sub(temp2);
-            temp2.setFrom(temp1).scale(invMassB);
+            temp2..setFrom(temp1)..scale(invMassB);
             vB.add(temp2);
 
             wA -= invIA * (cp1.rA.cross(P1) + cp2.rA.cross(P2));
@@ -514,8 +514,8 @@ class ContactSolver {
         Vector2 point = psm.point;
         double separation = psm.separation;
 
-        rA.setFrom(point).sub(bodyA.sweep.center);
-        rB.setFrom(point).sub(bodyB.sweep.center);
+        rA..setFrom(point)..sub(bodyA.sweep.center);
+        rB..setFrom(point)..sub(bodyB.sweep.center);
 
         // Track max constraint error.
         minSeparation = Math.min(minSeparation, separation);
@@ -533,14 +533,14 @@ class ContactSolver {
         // Compute normal impulse
         double impulse = K > 0.0 ? -C / K : 0.0;
 
-        P.setFrom(normal).scale(impulse);
+        P..setFrom(normal)..scale(impulse);
 
-        temp1.setFrom(P).scale(invMassA);
+        temp1..setFrom(P)..scale(invMassA);
         bodyA.sweep.center.sub(temp1);;
         bodyA.sweep.angle -= invIA * rA.cross(P);
         bodyA.synchronizeTransform();
 
-        temp1.setFrom(P).scale(invMassB);
+        temp1..setFrom(P)..scale(invMassB);
         bodyB.sweep.center.add(temp1);
         bodyB.sweep.angle += invIB * rB.cross(P);
         bodyB.synchronizeTransform();
@@ -576,14 +576,14 @@ class PositionSolverManifold {
         cc.bodyB.getWorldPointToOut(cc.points[0].localPoint, pointB);
         if (MathBox.distanceSquared(pointA, pointB) >
             Settings.EPSILON * Settings.EPSILON){
-          normal.setFrom(pointB).sub(pointA);
+          normal..setFrom(pointB)..sub(pointA);
           normal.normalize();
         } else {
           normal.setValues(1.0, 0.0);
         }
 
-        point.setFrom(pointA).add(pointB).scale(.5);
-        temp.setFrom(pointB).sub(pointA);
+        point..setFrom(pointA)..add(pointB)..scale(.5);
+        temp..setFrom(pointB)..sub(pointA);
         separation = temp.dot(normal) - cc.radius;
         break;
 
@@ -593,7 +593,7 @@ class PositionSolverManifold {
 
         cc.bodyB.getWorldPointToOut(cc.points[index].localPoint,
             clipPoint);
-        temp.setFrom(clipPoint).sub(planePoint);
+        temp..setFrom(clipPoint)..sub(planePoint);
         separation = temp.dot(normal) - cc.radius;
         point.setFrom(clipPoint);
         break;
@@ -603,7 +603,7 @@ class PositionSolverManifold {
         cc.bodyB.getWorldPointToOut(cc.localPoint, planePoint);
 
         cc.bodyA.getWorldPointToOut(cc.points[index].localPoint, clipPoint);
-        temp.setFrom(clipPoint).sub(planePoint);
+        temp..setFrom(clipPoint)..sub(planePoint);
         separation = temp.dot(normal) - cc.radius;
         point.setFrom(clipPoint);
 

--- a/lib/src/dynamics/contacts/time_of_impact_solver.dart
+++ b/lib/src/dynamics/contacts/time_of_impact_solver.dart
@@ -114,8 +114,8 @@ class TimeOfImpactSolver {
         Vector2 point = psm.point;
         num separation = psm.separation;
 
-        rA.setFrom(point).sub(bodyA.sweep.center);
-        rB.setFrom(point).sub(bodyB.sweep.center);
+        rA..setFrom(point)..sub(bodyA.sweep.center);
+        rB..setFrom(point)..sub(bodyB.sweep.center);
 
         // Track max constraint error.
         minSeparation = Math.min(minSeparation, separation);
@@ -132,14 +132,14 @@ class TimeOfImpactSolver {
         // Compute normal impulse
         num impulse = K > 0.0 ? -C / K : 0.0;
 
-        P.setFrom(normal).scale(impulse);
+        P..setFrom(normal)..scale(impulse);
 
-        temp.setFrom(P).scale(invMassA);
+        temp..setFrom(P)..scale(invMassA);
         bodyA.sweep.center.sub(temp);
         bodyA.sweep.angle -= invIA * rA.cross(P);
         bodyA.synchronizeTransform();
 
-        temp.setFrom(P).scale(invMassB);
+        temp..setFrom(P)..scale(invMassB);
         bodyB.sweep.center.add(temp);
         bodyB.sweep.angle += invIB * rB.cross(P);
         bodyB.synchronizeTransform();
@@ -176,14 +176,14 @@ class TimeOfImpactSolverManifold {
         pointB.setFrom(cc.bodyB.getWorldPoint(cc.localPoints[0]));
         if (MathBox.distanceSquared(pointA, pointB) > Settings.EPSILON
             * Settings.EPSILON) {
-          normal.setFrom(pointB).sub(pointA);
+          normal..setFrom(pointB)..sub(pointA);
           normal.normalize();
         } else {
           normal.setValues(1.0, 0.0);
         }
 
-        point.setFrom(pointA).add(pointB).scale(.5);
-        temp.setFrom(pointB).sub(pointA);
+        point..setFrom(pointA)..add(pointB)..scale(.5);
+        temp..setFrom(pointB)..sub(pointA);
         separation = temp.dot(normal) - cc.radius;
         break;
 
@@ -192,7 +192,7 @@ class TimeOfImpactSolverManifold {
         planePoint.setFrom(cc.bodyA.getWorldPoint(cc.localPoint));
 
         clipPoint.setFrom(cc.bodyB.getWorldPoint(cc.localPoints[index]));
-        temp.setFrom(clipPoint).sub(planePoint);
+        temp..setFrom(clipPoint)..sub(planePoint);
         separation = temp.dot(normal) - cc.radius;
         point.setFrom(clipPoint);
         break;
@@ -202,7 +202,7 @@ class TimeOfImpactSolverManifold {
         planePoint.setFrom(cc.bodyB.getWorldPoint(cc.localPoint));
 
         clipPoint.setFrom(cc.bodyA.getWorldPoint(cc.localPoints[index]));
-        temp.setFrom(clipPoint).sub(planePoint);
+        temp..setFrom(clipPoint)..sub(planePoint);
         separation = temp.dot(normal) - cc.radius;
         point.setFrom(clipPoint);
 

--- a/lib/src/dynamics/joints/distance_joint.dart
+++ b/lib/src/dynamics/joints/distance_joint.dart
@@ -152,7 +152,7 @@ class DistanceJoint extends Joint {
     v1.add(b1.linearVelocity);
     v2.add(b2.linearVelocity);
 
-    num Cdot = u.dot(v2.sub(v1));
+    num Cdot = u.dot(v2..sub(v1));
 
     num imp = -mass * (Cdot + bias + gamma * impulse);
     impulse += imp;

--- a/lib/src/dynamics/joints/distance_joint.dart
+++ b/lib/src/dynamics/joints/distance_joint.dart
@@ -67,8 +67,8 @@ class DistanceJoint extends Joint {
     Vector2 r2 = new Vector2.zero();
 
     // Compute the effective mass matrix.
-    r1.setFrom(localAnchor1).sub(b1.localCenter);
-    r2.setFrom(localAnchor2).sub(b2.localCenter);
+    r1..setFrom(localAnchor1)..sub(b1.localCenter);
+    r2..setFrom(localAnchor2)..sub(b2.localCenter);
     b1.originTransform.rotation.transformed(r1, r1);
     b2.originTransform.rotation.transformed(r2, r2);
 
@@ -118,7 +118,7 @@ class DistanceJoint extends Joint {
       impulse *= step.dtRatio;
 
       Vector2 P = new Vector2.zero();
-      P.setFrom(u).scale(impulse);
+      P..setFrom(u)..scale(impulse);
 
       b1.linearVelocity.x -= b1.invMass * P.x;
       b1.linearVelocity.y -= b1.invMass * P.y;
@@ -139,8 +139,8 @@ class DistanceJoint extends Joint {
     final r1 = new Vector2.zero();
     final r2 = new Vector2.zero();
 
-    r1.setFrom(localAnchor1).sub(b1.localCenter);
-    r2.setFrom(localAnchor2).sub(b2.localCenter);
+    r1..setFrom(localAnchor1)..sub(b1.localCenter);
+    r2..setFrom(localAnchor2)..sub(b2.localCenter);
     b1.originTransform.rotation.transformed(r1, r1);
     b2.originTransform.rotation.transformed(r2, r2);
 
@@ -179,8 +179,8 @@ class DistanceJoint extends Joint {
     final r2 = new Vector2.zero();
     final d = new Vector2.zero();
 
-    r1.setFrom(localAnchor1).sub(b1.localCenter);
-    r2.setFrom(localAnchor2).sub(b2.localCenter);
+    r1..setFrom(localAnchor1)..sub(b1.localCenter);
+    r2..setFrom(localAnchor2)..sub(b2.localCenter);
     b1.originTransform.rotation.transformed(r1, r1);
     b2.originTransform.rotation.transformed(r2, r2);
 

--- a/lib/src/dynamics/joints/friction_joint.dart
+++ b/lib/src/dynamics/joints/friction_joint.dart
@@ -40,7 +40,7 @@ class FrictionJoint extends Joint {
   }
 
   void getReactionForce(num inv_dt, Vector2 argOut) {
-    argOut.setFrom(_linearImpulse).scale(inv_dt);
+    argOut..setFrom(_linearImpulse)..scale(inv_dt);
   }
 
   double getReactionTorque(num inv_dt) => inv_dt * _angularImpulse;
@@ -64,8 +64,8 @@ class FrictionJoint extends Joint {
     Vector2 r1 = new Vector2.zero();
     Vector2 r2 = new Vector2.zero();
 
-    r1.setFrom(_localAnchorA).sub(bodyA.localCenter);
-    r2.setFrom(_localAnchorB).sub(bodyB.localCenter);
+    r1..setFrom(_localAnchorA)..sub(bodyA.localCenter);
+    r2..setFrom(_localAnchorB)..sub(bodyB.localCenter);
     bodyA.originTransform.rotation.transformed(r1, r1);
     bodyB.originTransform.rotation.transformed(r2, r2);
 
@@ -138,8 +138,8 @@ class FrictionJoint extends Joint {
       Vector2 r1 = new Vector2.zero();
       Vector2 r2 = new Vector2.zero();
 
-      r1.setFrom(_localAnchorA).sub(bodyA.localCenter);
-      r2.setFrom(_localAnchorB).sub(bodyB.localCenter);
+      r1..setFrom(_localAnchorA)..sub(bodyA.localCenter);
+      r2..setFrom(_localAnchorB)..sub(bodyB.localCenter);
       bodyA.originTransform.rotation.transformed(r1, r1);
       bodyB.originTransform.rotation.transformed(r2, r2);
 
@@ -149,7 +149,7 @@ class FrictionJoint extends Joint {
       r1.scaleOrthogonalInto(bodyA.angularVelocity, temp);
       r1.scaleOrthogonalInto(bodyB.angularVelocity, Cdot);
 
-      Cdot.add(bodyB.linearVelocity).sub(bodyA.linearVelocity).sub(temp);
+      Cdot..add(bodyB.linearVelocity)..sub(bodyA.linearVelocity)..sub(temp);
 
       Matrix2 K = new Matrix2(
           bodyA.invMass + bodyB.invMass +
@@ -177,7 +177,7 @@ class FrictionJoint extends Joint {
         _linearImpulse.scale(maxImpulse);
       }
 
-      impulse.setFrom(_linearImpulse).sub(oldImpulse);
+      impulse..setFrom(_linearImpulse)..sub(oldImpulse);
 
       bodyA.linearVelocity.x -= impulse.x * bodyA.invMass;
       bodyA.linearVelocity.y -= impulse.y * bodyA.invMass;

--- a/lib/src/dynamics/joints/revolute_joint.dart
+++ b/lib/src/dynamics/joints/revolute_joint.dart
@@ -79,8 +79,8 @@ class RevoluteJoint extends Joint {
     final Vector2 r2 = new Vector2.zero();
 
     // Compute the effective mass matrix.
-    r1.setFrom(localAnchor1).sub(b1.localCenter);
-    r2.setFrom(localAnchor2).sub(b2.localCenter);
+    r1..setFrom(localAnchor1)..sub(b1.localCenter);
+    r2..setFrom(localAnchor2)..sub(b2.localCenter);
     b1.originTransform.rotation.transformed(r1, r1);
     b2.originTransform.rotation.transformed(r2, r2);
 
@@ -141,11 +141,11 @@ class RevoluteJoint extends Joint {
       Vector2 P = new Vector2.zero();
       P.setValues(impulse.x, impulse.y);
 
-      temp.setFrom(P).scale(m1);
+      temp..setFrom(P)..scale(m1);
       b1.linearVelocity.sub(temp);
       b1.angularVelocity -= i1 * (r1.cross(P) + _motorImpulse + impulse.z);
 
-      temp.setFrom(P).scale(m2);
+      temp..setFrom(P)..scale(m2);
       b2.linearVelocity.add(temp);
       b2.angularVelocity += i2 * (r2.cross(P) + _motorImpulse + impulse.z);
 
@@ -188,8 +188,8 @@ class RevoluteJoint extends Joint {
     // Solve limit constraint.
     if (_enableLimit && limitState != LimitState.INACTIVE) {
 
-      r1.setFrom(localAnchor1).sub(b1.localCenter);
-      r2.setFrom(localAnchor2).sub(b2.localCenter);
+      r1..setFrom(localAnchor1)..sub(b1.localCenter);
+      r2..setFrom(localAnchor2)..sub(b2.localCenter);
       b1.originTransform.rotation.transformed(r1, r1);
       b2.originTransform.rotation.transformed(r2, r2);
 
@@ -199,19 +199,19 @@ class RevoluteJoint extends Joint {
       // Solve point-to-point constraint
       r1.scaleOrthogonalInto(w1, temp);
       r2.scaleOrthogonalInto(w2, Cdot1);
-      Cdot1.add(v2).sub(v1).sub(temp);
+      Cdot1..add(v2)..sub(v1)..sub(temp);
       num Cdot2 = w2 - w1;
       Cdot.setValues(Cdot1.x, Cdot1.y, Cdot2);
 
       Vector3 imp = new Vector3.zero();
-      Matrix3.solve(mass, imp, Cdot.negate());
+      Matrix3.solve(mass, imp, Cdot..negate());
 
       if (limitState == LimitState.EQUAL) {
         impulse.add(imp);
       } else if (limitState == LimitState.AT_LOWER) {
         num newImpulse = impulse.z + imp.z;
         if (newImpulse < 0.0) {
-          Matrix3.solve2(mass, temp, Cdot1.negate());
+          Matrix3.solve2(mass, temp, Cdot1..negate());
           imp.x = temp.x;
           imp.y = temp.y;
           imp.z = -impulse.z;
@@ -222,7 +222,7 @@ class RevoluteJoint extends Joint {
       } else if (limitState == LimitState.AT_UPPER) {
         num newImpulse = impulse.z + imp.z;
         if (newImpulse > 0.0) {
-          Matrix3.solve2(mass, temp, Cdot1.negate());
+          Matrix3.solve2(mass, temp, Cdot1..negate());
           imp.x = temp.x;
           imp.y = temp.y;
           imp.z = -impulse.z;
@@ -235,17 +235,17 @@ class RevoluteJoint extends Joint {
 
       P.setValues(imp.x, imp.y);
 
-      temp.setFrom(P).scale(m1);
+      temp..setFrom(P)..scale(m1);
       v1.sub(temp);
       w1 -= i1 * (r1.cross(P) + imp.z);
 
-      temp.setFrom(P).scale(m2);
+      temp..setFrom(P)..scale(m2);
       v2.add(temp);
       w2 += i2 * (r2.cross(P) + imp.z);
 
     } else {
-      r1.setFrom(localAnchor1).sub(b1.localCenter);
-      r2.setFrom(localAnchor2).sub(b2.localCenter);
+      r1..setFrom(localAnchor1)..sub(b1.localCenter);
+      r2..setFrom(localAnchor2)..sub(b2.localCenter);
       b1.originTransform.rotation.transformed(r1, r1);
       b2.originTransform.rotation.transformed(r2, r2);
 
@@ -255,17 +255,17 @@ class RevoluteJoint extends Joint {
 
       r1.scaleOrthogonalInto(w1, temp);
       r2.scaleOrthogonalInto(w2, Cdot);
-      Cdot.add(v2).sub(v1).sub(temp);
-      Matrix3.solve2(mass, imp, Cdot.negate()); // just leave negated
+      Cdot..add(v2)..sub(v1)..sub(temp);
+      Matrix3.solve2(mass, imp, Cdot..negate()); // just leave negated
 
       impulse.x += imp.x;
       impulse.y += imp.y;
 
-      temp.setFrom(imp).scale(m1);
+      temp..setFrom(imp)..scale(m1);
       v1.sub(temp);
       w1 -= i1 * r1.cross(imp);
 
-      temp.setFrom(imp).scale(m2);
+      temp..setFrom(imp)..scale(m2);
       v2.add(temp);
       w2 += i2 * r2.cross(imp);
     }
@@ -325,13 +325,13 @@ class RevoluteJoint extends Joint {
       Vector2 r2 = new Vector2.zero();
       Vector2 C = new Vector2.zero();
 
-      r1.setFrom(localAnchor1).sub(b1.localCenter);
-      r2.setFrom(localAnchor2).sub(b2.localCenter);
+      r1..setFrom(localAnchor1)..sub(b1.localCenter);
+      r2..setFrom(localAnchor2)..sub(b2.localCenter);
       b1.originTransform.rotation.transformed(r1, r1);
       b2.originTransform.rotation.transformed(r2, r2);
 
-      C.setFrom(b2.sweep.center).add(r2);
-      C.sub(b1.sweep.center).sub(r1);
+      C..setFrom(b2.sweep.center)..add(r2);
+      C..sub(b1.sweep.center)..sub(r1);
       positionError = C.length;
 
       num invMass1 = b1.invMass, invMass2 = b2.invMass;
@@ -347,16 +347,16 @@ class RevoluteJoint extends Joint {
         if (m > 0.0) {
           m = 1.0 / m;
         }
-        imp.setFrom(C).negate().scale(m);
+        imp..setFrom(C)..negate()..scale(m);
         final num k_beta = 0.5;
         // using u as temp variable
-        u.setFrom(imp).scale(k_beta * invMass1);
+        u..setFrom(imp)..scale(k_beta * invMass1);
         b1.sweep.center.sub(u);
-        u.setFrom(imp).scale(k_beta * invMass2);
+        u..setFrom(imp)..scale(k_beta * invMass2);
         b2.sweep.center.add(u);
 
-        C.setFrom(b2.sweep.center).add(r2);
-        C.sub(b1.sweep.center).sub(r1);
+        C..setFrom(b2.sweep.center)..add(r2);
+        C..sub(b1.sweep.center)..sub(r1);
       }
 
       Matrix2 K1 = new Matrix2(
@@ -377,15 +377,15 @@ class RevoluteJoint extends Joint {
        -invI2 * r2.x * r2.y,
        invI2 * r2.x * r2.x);
 
-      K1.add(K2).add(K3);
-      Matrix2.solve(K1, imp, C.negate()); // just leave c negated
+      K1..add(K2)..add(K3);
+      Matrix2.solve(K1, imp, C..negate()); // just leave c negated
 
       // using C as temp variable
-      C.setFrom(imp).scale(b1.invMass);
+      C..setFrom(imp)..scale(b1.invMass);
       b1.sweep.center.sub(C);
       b1.sweep.angle -= b1.invInertia * r1.cross(imp);
 
-      C.setFrom(imp).scale(b2.invMass);
+      C..setFrom(imp)..scale(b2.invMass);
       b2.sweep.center.add(C);
       b2.sweep.angle += b2.invInertia * r2.cross(imp);
 
@@ -406,7 +406,7 @@ class RevoluteJoint extends Joint {
   }
 
   void getReactionForce(num inv_dt, Vector2 argOut) {
-    argOut.setValues(impulse.x, impulse.y).scale(inv_dt);
+    argOut..setValues(impulse.x, impulse.y)..scale(inv_dt);
   }
 
   num getReactionTorque(num inv_dt) {


### PR DESCRIPTION
There is a pull-request landing in vector_math soon that removes call chaining from the library (and also comes with many dart2js related improvments).
The problems that my changes to vector_math introduce can be solved by using the .. operator.

This change also works without the pull requets in vector_math. But I'm not sure if I covered all required changes. The demos are working fine, but during testing the demo I noticed that the analyzer missed at leas one problem (http://dartbug.com/17680).
